### PR TITLE
feat(response): Added [subscription_count] field to the responses.

### DIFF
--- a/src/networking/Rest/Routes/subscriptions.ts
+++ b/src/networking/Rest/Routes/subscriptions.ts
@@ -50,7 +50,8 @@ router.post("/:guildID/:channelID", async (req, res) => {
     const success = await client.subscribe(guildID as Snowflake, channelID as Snowflake, Boolean(req.query.self_deaf));
 
     return res.status(201).json({
-        success
+        success,
+        subscription_count: client.subscriptions.size
     });
 });
 
@@ -76,7 +77,7 @@ router.delete("/:guildID/:channelID", (req, res) => {
 
     client.subscriptions.delete(guildID as Snowflake);
 
-    return res.status(204).json();
+    return res.status(200).json({ subscription_count: client.subscriptions.size });
 });
 
 export default router;


### PR DESCRIPTION
## Changes
It is easy to know the number of subscriptions has been done by sending the `subscription_count` field at the responses of `POST  /:guildID/:channelID` and `DELETE /:guildID/:channelID`.

## Status

- [ ] These changes have been tested and formatted properly.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
